### PR TITLE
feat: 채팅 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@react-three/drei": "^9.105.6",
         "@react-three/fiber": "^8.16.3",
+        "@stomp/stompjs": "^7.0.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.8",
         "gltfjsx": "^6.2.16",
+        "http-proxy-middleware": "^3.0.0",
         "query-string": "^9.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3740,6 +3742,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.0.0.tgz",
+      "integrity": "sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -10462,26 +10469,19 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
+      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -19727,6 +19727,29 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -22994,6 +23017,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "@stomp/stompjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.0.0.tgz",
+      "integrity": "sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw=="
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -27934,15 +27962,16 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
+      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
       "requires": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
       }
     },
     "https-proxy-agent": {
@@ -34465,6 +34494,18 @@
           "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
           "requires": {
             "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+          "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+          "requires": {
+            "@types/http-proxy": "^1.17.8",
+            "http-proxy": "^1.18.1",
+            "is-glob": "^4.0.1",
+            "is-plain-obj": "^3.0.0",
+            "micromatch": "^4.0.2"
           }
         },
         "json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "dependencies": {
     "@react-three/drei": "^9.105.6",
     "@react-three/fiber": "^8.16.3",
+    "@stomp/stompjs": "^7.0.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.8",
     "gltfjsx": "^6.2.16",
+    "http-proxy-middleware": "^3.0.0",
     "query-string": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/pages/Chat.js
+++ b/src/pages/Chat.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import io from "socket.io-client";
 import queryString from "query-string";
 import { IoSend } from "react-icons/io5";
+import * as StompJs from "@stomp/stompjs";
 
 import "./Chat.scss";
 
@@ -16,34 +17,145 @@ const Chat = () => {
   const me = location.state.me;
   const name = location.state.name;
   const artist = location.state.artist;
-  const [messages, setMessages] = useState([]);
-  const [inputMessage, setInputMessage] = useState("");
+
+  const param = useParams();
+  const chatRoomId = "7a0430fd-5d94-4d09-80f7-2243461a3217";
+  const accessToken = JSON.stringify(window.localStorage.getItem("accessToken"));
+
+  let [client, changeClient] = useState(null);
+  const [chat, setChat] = useState(""); // 입력된 chat을 받을 변수
+  const [chatList, setChatList] = useState([]); // 채팅 기록
+
+
+  // const msgBox = chatList.map((item, idx) => {
+  //   if (Number(item.sender)!== userId) {
+  //     return (
+  //       <div key={idx} className={styles.otherchat}>
+  //         <div className={styles.otherimg}>
+  //           <img src={testImg} alt="" />
+  //         </div>
+  //         <div className={styles.othermsg}>
+  //           <span>{item.data}</span>
+  //         </div>
+  //         <span className={styles.otherdate}>{item.date}</span>
+  //       </div>
+  //     );
+  //   } else {
+  //     return (
+  //       <div key={idx} className={styles.mychat}>
+  //         <div className={styles.mymsg}>
+  //           <span>{item.data}</span>
+  //         </div>
+  //         <span className={styles.mydate}>{item.date}</span>
+  //       </div>
+  //     );
+  //   }
+  // });
+
+
+
+
+  const connect = () => {
+    // 소켓 연결
+    try {
+      const clientdata = new StompJs.Client({
+        brokerURL: "ws://localhost:8080/ws/chat",
+        connectHeaders: {
+          Authorization: window.localStorage.getItem("accessToken")
+        },
+        debug: function (str) {
+          console.log(str);
+        },
+        reconnectDelay: 5000, // 자동 재 연결
+        heartbeatIncoming: 4000,
+        heartbeatOutgoing: 4000,
+      });
+
+      // 구독
+      clientdata.onConnect = function () {
+        clientdata.subscribe("/sub/chat/" + chatRoomId, callback);
+      };
+
+      clientdata.activate(); // 클라이언트 활성화
+      changeClient(clientdata); // 클라이언트 갱신
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const disConnect = () => {
+    // 연결 끊기
+    if (client === null) {
+      return;
+    }
+    client.deactivate();
+  };
+
+  // 콜백함수 => ChatList 저장하기
+  const callback = function (message) {
+    if (message.body) {
+      let msg = JSON.parse(message.body);
+      console.log(msg);
+      setChatList((chats) => [...chats, msg]);
+    }
+  };
+
+  const sendChat = () => {
+    if (chat === "") {
+      return;
+    }
+
+    client.publish({
+      destination: "/pub/chat/" + chatRoomId,
+      body: JSON.stringify({
+        message: chat,
+      }),
+    });
+
+    setChat("");
+  };
+
+  useEffect(() => {
+    // 최초 렌더링 시 , 웹소켓에 연결
+    // 우리는 사용자가 방에 입장하자마자 연결 시켜주어야 하기 때문에,,
+    connect();
+
+    return () => disConnect();
+  }, []);
+
+  const onChangeChat = (e) => {
+    setChat(e.target.value);
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+  };
 
   // 방 있는지 검사(이메일 포스트해주면 방 아이디 받아옴)
   // 방 아이디 받아옴
   // socketseverurl에 말씀해주신 추가 endpoint(/pub/chat/{roomId})로 socket io 작성
 
-  const socket = io(SOCKET_SERVER_URL);
-  useEffect(() => {
-    //const { name, room } = queryString.parse(window.location.search)
-    // 컴포넌트가 마운트될 때 소켓 연결
-    socket.on("message", (message) => {
-      setMessages((prevMessages) => [...prevMessages, message]);
-    });
+  // const socket = io(SOCKET_SERVER_URL);
+  // useEffect(() => {
+  //   //const { name, room } = queryString.parse(window.location.search)
+  //   // 컴포넌트가 마운트될 때 소켓 연결
+  //   socket.on("message", (message) => {
+  //     setMessages((prevMessages) => [...prevMessages, message]);
+  //   });
 
-    // 컴포넌트가 언마운트될 때 소켓 연결 해제
-    return () => {
-      socket.disconnect();
-    };
-  }, [socket]);
+  //   // 컴포넌트가 언마운트될 때 소켓 연결 해제
+  //   return () => {
+  //     socket.disconnect();
+  //   };
+  // }, [socket]);
 
-  const handleMessageSubmit = (e) => {
-    e.preventDefault();
-    if (inputMessage.trim() !== "") {
-      socket.emit("message", inputMessage);
-      setInputMessage("");
-    }
-  };
+  // const handleMessageSubmit = (e) => {
+  //   e.preventDefault();
+  //   if (inputMessage.trim() !== "") {
+  //     socket.emit("message", inputMessage);
+  //     setInputMessage("");
+  //   }
+  // };
 
   const onClick = () => {
     navigate(-1);
@@ -62,17 +174,22 @@ const Chat = () => {
           </button>
         </div>
         <div className="PrevMessages">
-          {messages.map((msg, index) => (
-            <div key={index}>{msg}</div>
+          {chatList.map((msg, index) => (
+            <div key={index}>{msg.message}</div>
           ))}
         </div>
         <div className="SendMessage">
-          <form onSubmit={handleMessageSubmit}>
+          <form onSubmit={handleSubmit}>
             <input
               type="text"
-              value={inputMessage}
-              onChange={(e) => setInputMessage(e.target.value)}
+              value={chat}
+              onChange={onChangeChat}
               placeholder="메시지를 입력하세요."
+              onKeyDown={(ev) => {
+                if (ev.keyCode === 13) {
+                  sendChat();
+                }
+              }}
             />
             <button type="submit">
               <IoSend size={30} />

--- a/src/pages/Chat.js
+++ b/src/pages/Chat.js
@@ -4,13 +4,36 @@ import io from "socket.io-client";
 import queryString from "query-string";
 import { IoSend } from "react-icons/io5";
 import * as StompJs from "@stomp/stompjs";
-
+import axios from 'axios';
 import "./Chat.scss";
 
 const SOCKET_SERVER_URL = "ws://localhost:8080/ws/chat";
-// url은 ws://localhost:8080/ws/chat이 될 예정
 
 const Chat = () => {
+  function getRoomId() {
+    const accessToken = localStorage.getItem('accessToken')
+
+    fetch("http://localhost:8080/chat/room",{
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${accessToken}`
+      },
+      body: JSON.stringify({
+        receiverEmail: "ms9648@naver.com", // receiverEmail 넣어주기.
+        sender: localStorage.getItem("user_id")
+      }),
+    })
+    .then((response) => response.json())
+      .then((response) => {
+        console.log(response.roomId);
+        setChatRoomId(response.roomId);
+        console.log("chatRoomId"+chatRoomId);
+      })
+      .catch(() => {
+        alert("에러났어요.");
+      });
+  };
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -19,41 +42,49 @@ const Chat = () => {
   const artist = location.state.artist;
 
   const param = useParams();
-  const chatRoomId = "7a0430fd-5d94-4d09-80f7-2243461a3217";
-  const accessToken = JSON.stringify(window.localStorage.getItem("accessToken"));
+  const accessToken = localStorage.getItem("accessToken");
+  const userId = localStorage.getItem("user_id")
+  // const receiverEmail = getReceiverEmail(); 상대방 이메일 알아야 함.
 
   let [client, changeClient] = useState(null);
   const [chat, setChat] = useState(""); // 입력된 chat을 받을 변수
   const [chatList, setChatList] = useState([]); // 채팅 기록
+  
+  const [chatRoomId, setChatRoomId] = useState("");
 
-
-  // const msgBox = chatList.map((item, idx) => {
-  //   if (Number(item.sender)!== userId) {
-  //     return (
-  //       <div key={idx} className={styles.otherchat}>
-  //         <div className={styles.otherimg}>
-  //           <img src={testImg} alt="" />
-  //         </div>
-  //         <div className={styles.othermsg}>
-  //           <span>{item.data}</span>
-  //         </div>
-  //         <span className={styles.otherdate}>{item.date}</span>
-  //       </div>
-  //     );
-  //   } else {
-  //     return (
-  //       <div key={idx} className={styles.mychat}>
-  //         <div className={styles.mymsg}>
-  //           <span>{item.data}</span>
-  //         </div>
-  //         <span className={styles.mydate}>{item.date}</span>
-  //       </div>
-  //     );
-  //   }
-  // });
-
-
-
+  const msgBox = chatList.map((msg, index) => {
+    // 상대방의 채팅 내역일 경우
+    if (String(msg.sender.email) !== userId) {
+      return (
+        <div key={index} className="otherChat">
+          {/* 상대방 이미지 */}
+          <div className="otherImg">
+            <img src="/favicon.ico" alt="" />
+          </div>
+          {/* 상대방 채팅 내용 */}
+          <div className="otherChatBox">
+            <div className="otherMsg">
+              <span>{msg.message}</span>
+            </div>
+            {/* 채팅 보낸 시각 */}
+            <span className="otherChatTime">{msg.message.sendTime}</span>
+          </div>
+        </div>
+      );
+    }
+    else {
+      return (
+        <div key={index} className="myChat">
+          <div className="myChatBox">
+            <span className="myChatTime">{String(msg.sendTime).split('T')[1].substring(0,5)}</span>
+            <div className="myMsg">
+              <span>{msg.message}</span>
+            </div>
+          </div>
+        </div>
+      );
+    }
+  })
 
   const connect = () => {
     // 소켓 연결
@@ -61,7 +92,7 @@ const Chat = () => {
       const clientdata = new StompJs.Client({
         brokerURL: "ws://localhost:8080/ws/chat",
         connectHeaders: {
-          Authorization: window.localStorage.getItem("accessToken")
+          "Authorization": `Bearer ${accessToken}`
         },
         debug: function (str) {
           console.log(str);
@@ -75,7 +106,7 @@ const Chat = () => {
       clientdata.onConnect = function () {
         clientdata.subscribe("/sub/chat/" + chatRoomId, callback);
       };
-
+      
       clientdata.activate(); // 클라이언트 활성화
       changeClient(clientdata); // 클라이언트 갱신
     } catch (err) {
@@ -97,31 +128,44 @@ const Chat = () => {
       let msg = JSON.parse(message.body);
       console.log(msg);
       setChatList((chats) => [...chats, msg]);
+      console.log(chatList);
     }
   };
 
   const sendChat = () => {
+    
     if (chat === "") {
       return;
     }
-
     client.publish({
       destination: "/pub/chat/" + chatRoomId,
       body: JSON.stringify({
         message: chat,
+        sender: userId
       }),
+      header: {
+        "Authorization": `Bearer ${accessToken}`
+      },
     });
 
     setChat("");
   };
 
   useEffect(() => {
+    getRoomId(); // 렌더링 시 roomId를 반환하여 chatRoomId에 저장한 후 pub/chat/{chatRoomId} 에 메시지를 보내야 함
     // 최초 렌더링 시 , 웹소켓에 연결
     // 우리는 사용자가 방에 입장하자마자 연결 시켜주어야 하기 때문에,,
-    connect();
 
-    return () => disConnect();
   }, []);
+
+  useEffect(() => {
+    // chatRoomId가 설정되었을 때 connect() 함수 호출
+    if (chatRoomId) {
+      connect();
+    }
+    return () => disConnect();
+  }, [chatRoomId]); 
+
 
   const onChangeChat = (e) => {
     setChat(e.target.value);
@@ -130,32 +174,6 @@ const Chat = () => {
   const handleSubmit = (event) => {
     event.preventDefault();
   };
-
-  // 방 있는지 검사(이메일 포스트해주면 방 아이디 받아옴)
-  // 방 아이디 받아옴
-  // socketseverurl에 말씀해주신 추가 endpoint(/pub/chat/{roomId})로 socket io 작성
-
-  // const socket = io(SOCKET_SERVER_URL);
-  // useEffect(() => {
-  //   //const { name, room } = queryString.parse(window.location.search)
-  //   // 컴포넌트가 마운트될 때 소켓 연결
-  //   socket.on("message", (message) => {
-  //     setMessages((prevMessages) => [...prevMessages, message]);
-  //   });
-
-  //   // 컴포넌트가 언마운트될 때 소켓 연결 해제
-  //   return () => {
-  //     socket.disconnect();
-  //   };
-  // }, [socket]);
-
-  // const handleMessageSubmit = (e) => {
-  //   e.preventDefault();
-  //   if (inputMessage.trim() !== "") {
-  //     socket.emit("message", inputMessage);
-  //     setInputMessage("");
-  //   }
-  // };
 
   const onClick = () => {
     navigate(-1);
@@ -174,9 +192,7 @@ const Chat = () => {
           </button>
         </div>
         <div className="PrevMessages">
-          {chatList.map((msg, index) => (
-            <div key={index}>{msg.message}</div>
-          ))}
+          { msgBox }
         </div>
         <div className="SendMessage">
           <form onSubmit={handleSubmit}>

--- a/src/pages/Chat.scss
+++ b/src/pages/Chat.scss
@@ -40,8 +40,60 @@
       }
     }
     .PrevMessages {
-      height: 70vh;
+      height: 50vh;
       //background-color: #a9d0f5;
+      .otherChat{
+        display: flex;
+        justify-content: left;
+        margin-top: 10px;
+        margin-left: 20px;
+        text-align: right;
+        .otherImg > img{
+          border-radius: 30px;
+          width: 30px;
+          margin-right: 10px;
+        }
+        .otherChatBox{
+          display: inline-block;
+          position: relative;
+          background-color: #ea5936;
+          border-radius: 20px;
+          color: #fff;
+          padding: 7px 12px;
+          margin-bottom: 10px;
+          max-width: 230px;
+          .otherChatTime {
+            position: absolute;
+            left: -72px;
+            top: 15px;
+            color: #171717;
+          }
+        }
+      }
+      .myChat{
+        display: flex;
+        flex-direction: row;
+        justify-content: right;
+        margin-top: 10px;
+        margin-right: 20px;
+        text-align: right;
+        .myChatBox{
+          display: inline-block;
+          position: relative;
+          background-color: #ea5936;
+          border-radius: 20px;
+          color: #fff;
+          padding: 7px 12px;
+          margin-bottom: 10px;
+          max-width: 230px;
+          .myChatTime {
+            position: absolute;
+            left: -72px;
+            top: 15px;
+            color: #171717;
+          }
+        }
+      }
     }
     .SendMessage {
       margin-top: 20px;


### PR DESCRIPTION
![image](https://github.com/Jolvre/Jolvre_FE/assets/43836180/0da81d54-95a0-4329-8868-b3c20ac95d3b)


현재 기본적인 채팅 기능만 구현했습니다!

채팅 로직 순서는 다음과 같습니다.

1. 입장할 때 `getRoomId()`실행(roomId가 유효한지)
- 이 때, header에 엑세스 토큰을 담아서 보내야 합니다.
2. header 검증이 끝나면 OK & roomId 반환
3. `setChatRoomId()`로 roomId 저장
4. `connect()`요청 => /ws/chat으로 요청하고 `/sub/chat/${chatRoomId}` 구독
- `setChatRoomId()`가 수행되어 chatRoomId에 값이 들어갈 경우에만 웹 소켓 연결을 시도하도록 하였습니다.
   - 제가 리액트 동기식 요청을 잘 몰라서,, 일단 이렇게 했는데, 혹시 더 좋은 방법이 있으면 바꾸셔도 좋습니다!
5. 메시지 보낼 때는 `/pub/chat/${chatRoomId}`로 메시지를 보냄.
6. 페이지에서 나올 경우 자동으로 `disconnect()`가 수행되어 웹소켓 연결을 해제하도록 하였습니다.

### 추가로 구현해야할 사항
1. 푸쉬 알림 구현
- 알림의 경우 백엔드 단에서 해야하는지 프론트 단에서 해야하는지 아직 감이 안 와서 조금 더 공부 후에 구현하도록 하겠습니다.
2. 에러는,, 프로토타입 발표 이후에 에러처리 로직을 구현하도록 하겠습니다.